### PR TITLE
remove AVX2 compilations

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,41 +2,19 @@
 
 set -ex
 
-if [ -n "$OS_LINUX" ]; then
-  arches="default avx2"
-else
-  arches="default"
-fi
+tmp_obj=bitshuffle_default_tmp.o
+dst_obj=bitshuffle_default.o
 
-to_link=""
-for arch in $arches ; do
-  arch_flag=""
-  if [ "$arch" == "avx2" ]; then
-    arch_flag="-mavx2"
-  fi
-  tmp_obj=bitshuffle_${arch}_tmp.o
-  dst_obj=bitshuffle_${arch}.o
-  
-  ${CC:-gcc} $EXTRA_CFLAGS $arch_flag -std=c99 -I$PREFIX/include -O3 -DNDEBUG -fPIC -c \
-    "src/bitshuffle_core.c" \
-    "src/bitshuffle.c" \
-    "src/iochain.c"
-  
-  # Merge the object files together to produce a combined .o file.
-  ld -r -o $tmp_obj bitshuffle_core.o bitshuffle.o iochain.o
+${CC:-gcc} $EXTRA_CFLAGS -std=c99 -I$PREFIX/include -O3 -DNDEBUG -fPIC -c \
+  "src/bitshuffle_core.c" \
+  "src/bitshuffle.c" \
+  "src/iochain.c"
 
-  # For the AVX2 symbols, suffix them.
-  if [ "$arch" == "avx2" ]; then
-    # Create a mapping file with '<old_sym> <suffixed_sym>' on each line.
-    nm --defined-only --extern-only $tmp_obj | while read addr type sym ; do
-      echo ${sym} ${sym}_${arch}
-    done > renames.txt
-    objcopy --redefine-syms=renames.txt $tmp_obj $dst_obj
-  else
-    mv $tmp_obj $dst_obj
-  fi
-  to_link="$to_link $dst_obj"
-done
+# Merge the object files together to produce a combined .o file.
+ld -r -o $tmp_obj bitshuffle_core.o bitshuffle.o iochain.o
+
+mv $tmp_obj $dst_obj
+to_link="$to_link $dst_obj"
 
 rm -f bitshuffle.a
 ar rs bitshuffle.a $to_link

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,7 +5,7 @@ set -ex
 tmp_obj=bitshuffle_default_tmp.o
 dst_obj=bitshuffle_default.o
 
-${CC:-gcc} $EXTRA_CFLAGS -std=c99 -I$PREFIX/include -O3 -DNDEBUG -fPIC -c \
+${CC:-gcc} $CFLAGS $EXTRA_CFLAGS -std=c99 -I$PREFIX/include -DNDEBUG -c \
   "src/bitshuffle_core.c" \
   "src/bitshuffle.c" \
   "src/iochain.c"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,7 +5,7 @@ set -ex
 tmp_obj=bitshuffle_default_tmp.o
 dst_obj=bitshuffle_default.o
 
-${CC:-gcc} $CFLAGS $EXTRA_CFLAGS -std=c99 -I$PREFIX/include -DNDEBUG -c \
+$CC $CFLAGS $EXTRA_CFLAGS -std=c99 -I$PREFIX/include -DNDEBUG -c \
   "src/bitshuffle_core.c" \
   "src/bitshuffle.c" \
   "src/iochain.c"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patch/0001-Fix-plugin-tests-for-newer-h5py.patch
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: c3f4461d8013e3d9db0d58defec77b143164652de505a1fba3df088eaa19be2f
   patches:
     - patch/0001-Fix-plugin-tests-for-newer-h5py.patch
+    - patch/0002-Fix-compilation-flags.patch
 
 build:
   number: 4

--- a/recipe/patch/0002-Fix-compilation-flags.patch
+++ b/recipe/patch/0002-Fix-compilation-flags.patch
@@ -1,0 +1,26 @@
+From 275073137805b2ce930e3264f2047e4f18829f26 Mon Sep 17 00:00:00 2001
+From: Markus Gerstel <markus.gerstel@diamond.ac.uk>
+Date: Mon, 23 Mar 2020 10:43:27 +0000
+Subject: [PATCH] Do not override conda-forge compilation flags
+
+especially keep default architecture settings
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 830991c..cfa17c1 100644
+--- a/setup.py
++++ b/setup.py
+@@ -26,7 +26,7 @@ if VERSION_DEV:
+     VERSION = VERSION + ".dev%d" % VERSION_DEV
+ 
+ 
+-COMPILE_FLAGS = ['-O3', '-ffast-math', '-march=native', '-std=c99']
++COMPILE_FLAGS = ['-ffast-math', '-std=c99']
+ # Cython breaks strict aliasing rules.
+ COMPILE_FLAGS += ['-fno-strict-aliasing']
+ COMPILE_FLAGS += ['-fPIC']
+-- 
+2.16.5
+


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Build package without AVX2 on any platforms. Possibly resolves #7 

<!--
Please add any other relevant info below:
-->
