### PR TITLE
Fix compilation flags

### DIFF
--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -53,6 +53,25 @@ if [[ "${sha:-}" == "" ]]; then
   sha=$(git rev-parse HEAD)
 fi
 
+if [[ "${OSX_SDK_DIR:-}" == "" ]]; then
+  if [[ "${CI:-}" == "" ]]; then
+    echo "Please set OSX_SDK_DIR to a directory where SDKs can be downloaded to. Aborting"
+    exit 1
+  else
+    export OSX_SDK_DIR=/opt/conda-sdks
+    /usr/bin/sudo mkdir -p "${OSX_SDK_DIR}"
+    /usr/bin/sudo chown "${USER}" "${OSX_SDK_DIR}"
+  fi
+else
+  if tmpf=$(mktemp -p "$OSX_SDK_DIR" tmp.XXXXXXXX 2>/dev/null); then
+      rm -f "$tmpf"
+      echo "OSX_SDK_DIR is writeable without sudo, continuing"
+  else
+      echo "User-provided OSX_SDK_DIR is not writeable for current user! Aborting"
+      exit 1
+  fi
+fi
+
 echo -e "\n\nRunning the build setup script."
 source run_conda_forge_build_setup
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 name = "bitshuffle-feedstock"
-version = "3.53.3"  # conda-smithy version used to generate this file
+version = "3.54.1"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/bitshuffle-feedstock"
 authors = ["@conda-forge/bitshuffle"]
 channels = ["conda-forge"]

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -26,6 +26,12 @@ cp src/bitshuffle_core.h $PREFIX/include/bitshuffle_core.h
 if [[ $HOST == arm64-apple-* ]]; then
     # Bitshuffle forces usage of -mcpu=, defaulting to the invalid "native"
     export BITSHUFFLE_ARCH=apple-m1
+elif [[ $HOST == x86_64-apple-* ]]; then
+    # Bitshuffle forces usage of -march=, defaulting to "native", overwriting the conda-forge core2 value
+    export BITSHUFFLE_ARCH=core2
+elif [[ $HOST == x86_64-*-linux-* ]]; then
+    # Bitshuffle forces usage of -march=, defaulting to "native", overwriting the conda-forge nocona value
+    export BITSHUFFLE_ARCH=nocona
 fi
 
 HDF5_DIR=$PREFIX $PYTHON -m pip install . --no-deps -vv

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -17,7 +17,7 @@ source:
     - patch/0003-Remove-runtime-cython-dependency.patch
 
 build:
-  number: 8
+  number: 9
   skip: win
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

By default bitshuffle is adding `-march=native`, which overwrites the value set by conda-forge.
This can result in a package that can't be imported on older hardware (fix #62)

Force the same value used by conda-forge on osx-64 (`core2`) and linux-64 (`nocona`).

On osx-arm64, the value was already forced to `-mcpu=apple-m1`.

Note that for linux-aarch64, it's still using `-mcpu=native`. I'm not sure what else to force.
I tested the current package inside a docker container on my Apple M3 and I could import bitshuffle.